### PR TITLE
Minor changes in the README to improve developer experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ cd ~/environment/mender-convert
 mkdir -p input
 cd input
 wget http://downloads.raspberrypi.org/raspbian_lite/images/raspbian_lite-2019-04-09/2019-04-08-raspbian-stretch-lite.zip
-unzip raspbian_lite-2019-04-09/2019-04-08-raspbian-stretch-lite.zip
+unzip 2019-04-08-raspbian-stretch-lite.zip
 ```
 
 ### Modify the Wifi configuration

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ install -m 755 goagent overlay_root_fs/usr/sbin/goagent
 Download the Raspbian image and extract it:
 
 ```bash
-cd ..
+cd ~/environment/mender-convert
 mkdir -p input
 cd input
 wget http://downloads.raspberrypi.org/raspbian_lite/images/raspbian_lite-2019-04-09/2019-04-08-raspbian-stretch-lite.zip


### PR DESCRIPTION
*Description of changes:*
- Adjusted guidelines to ensure that the Raspian image gets downloaded in ~/environment/mender-convert/input folder. This is necessary for the steps in "Build the SD card image" section to work correctly.
- Removed unnecessary directory name in `unzip raspbian_lite-2019-04-0...`command

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
